### PR TITLE
Only call filter_matched when truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+  - Switches behavior of add_tag and add_field, now tags and fields are added only when the truncation happens 
+    on any field or nested field [#7](https://github.com/logstash-plugins/logstash-filter-truncate/pull/7).
+    
 ## 1.0.4
   - Update gemspec summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0
+## 1.0.5
   - Switches behavior of add_tag and add_field, now tags and fields are added only when the truncation happens 
     on any field or nested field [#7](https://github.com/logstash-plugins/logstash-filter-truncate/pull/7).
     

--- a/lib/logstash/filters/truncate.rb
+++ b/lib/logstash/filters/truncate.rb
@@ -49,8 +49,10 @@ class LogStash::Filters::Truncate < LogStash::Filters::Base
       truncated = Truncator.truncate_all(fields, event, @length_bytes)
     end
     
-    @logger.debug("truncated one or more fields from event to length #{@length_bytes}") if truncated
-    filter_matched(event) if truncated
+    if truncated
+      @logger.debug("truncated one or more fields from event to length #{@length_bytes}")
+      filter_matched(event)
+    end  
   end
 
   module Truncator

--- a/lib/logstash/filters/truncate.rb
+++ b/lib/logstash/filters/truncate.rb
@@ -49,6 +49,7 @@ class LogStash::Filters::Truncate < LogStash::Filters::Base
       truncated = Truncator.truncate_all(fields, event, @length_bytes)
     end
     
+    @logger.debug("truncated one or more fields from event to length #{@length_bytes}") if truncated
     filter_matched(event) if truncated
   end
 

--- a/lib/logstash/filters/truncate.rb
+++ b/lib/logstash/filters/truncate.rb
@@ -86,17 +86,17 @@ class LogStash::Filters::Truncate < LogStash::Filters::Base
     end
 
     def truncate_all(fields, event, length)
-      truncated = []
+      truncated = false
 
       fields.each do |field|
         before = event.get(field)
         truncate(event, field, length)
         after = event.get(field)
 
-        truncated.append(true) if before != after
+        truncated ||= (before != after)
       end
 
-      truncated.any?
+      truncated
     end
 
     def truncate(event, field, length)

--- a/lib/logstash/filters/truncate.rb
+++ b/lib/logstash/filters/truncate.rb
@@ -40,13 +40,16 @@ class LogStash::Filters::Truncate < LogStash::Filters::Base
 
   def filter(event)
     if @fields
-      @fields.each do |field|
-        Truncator.truncate(event, field, @length_bytes)
-      end
+      truncated = Truncator.truncate_all(fields, event, @length_bytes)
     else
-      Truncator.truncate_all(event, @length_bytes)
+      # TODO(sissel): I couldn't find a better way to get the top level keys for
+      # an event. Nor could I find a way to iterate over all the keys in an
+      # event, so this may have to suffice.
+      fields = event.to_hash.keys.map { |k| "[#{k}]" }
+      truncated = Truncator.truncate_all(fields, event, @length_bytes)
     end
-    filter_matched(event)
+    
+    filter_matched(event) if truncated
   end
 
   module Truncator
@@ -79,18 +82,23 @@ class LogStash::Filters::Truncate < LogStash::Filters::Base
       return v
     end
 
-    def truncate_all(event, length)
-      # TODO(sissel): I couldn't find a better way to get the top level keys for
-      # an event. Nor could I find a way to iterate over all the keys in an
-      # event, so this may have to suffice.
-      fields = event.to_hash.keys.map { |k| "[#{k}]" }
+    def truncate_all(fields, event, length)
+      truncated = []
+
       fields.each do |field|
+        before = event.get(field)
         truncate(event, field, length)
+        after = event.get(field)
+
+        truncated.append(true) if before != after
       end
+
+      truncated.any?
     end
 
     def truncate(event, field, length)
       value = event.get(field)
+
       if value.is_a?(String)
         event.set(field, trim(value, length))
       elsif value.is_a?(Array)

--- a/logstash-filter-truncate.gemspec
+++ b/logstash-filter-truncate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-truncate'
-  s.version         = '1.1.0'
+  s.version         = '1.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Truncates fields longer than a given length"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-truncate.gemspec
+++ b/logstash-filter-truncate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-truncate'
-  s.version         = '1.0.4'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Truncates fields longer than a given length"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/truncate_spec.rb
+++ b/spec/filters/truncate_spec.rb
@@ -107,14 +107,6 @@ describe LogStash::Filters::Truncate do
     it "should not modify `message`" do
       expect(event.get("message")).to be == text
     end
-
-#     stress_it "should only call filter_matched if a field was truncated" do
-#       if event.get("example").bytesize > length
-#         expect(subject).to receive(:filter_matched).once
-#       else
-#         expect(subject).not_to receive(:filter_matched)
-#       end
-#     end
   end
 
   context "with non-string fields" do
@@ -143,19 +135,13 @@ describe LogStash::Filters::Truncate do
       stress_it "should truncate all elements in a list" do
         count.times do |i|
           expect(event.get("[example][#{i}]").bytesize).to be <= length
-
-          if event.get("[example][#{i}]").bytesize > length
-            expect(subject).to receive(:filter_matched).once
-          else
-            expect(subject).not_to receive(:filter_matched)
-          end
         end
       end
     end
 
     context "containing elements greater than size" do
       let(:count) { 10 }
-      let(:list) { count.times.map { Flores::Random.text(100) } }
+      let(:list) { count.times.map { "a" * 100) } }
       let(:length) { 50 }
 
       it "should truncate all elements" do
@@ -171,7 +157,7 @@ describe LogStash::Filters::Truncate do
 
     context "containing elements with mixed sizes" do
       let(:count) { 10 }
-      let(:list) { (count - 1).times.map { Flores::Random.text(20) } + [Flores::Random.text(100)]}
+      let(:list) { (count - 1).times.map { "a" * 20 } + ["b" * 100]}
       let(:length) { 50 }
 
       it "should truncate elements that exceed the length" do

--- a/spec/filters/truncate_spec.rb
+++ b/spec/filters/truncate_spec.rb
@@ -14,39 +14,74 @@ describe LogStash::Filters::Truncate do
   analyze_results
 
   context "with hash fields" do
-    let(:data) {
-      {
-        "foo" => { "bar" => Flores::Random.text(0..1000) },
-        "one" => { "two" => { "three" => Flores::Random.text(0..1000) } },
-        "baz" => Flores::Random.text(0..1000),
+    context "stress test" do
+      let(:data) {
+        {
+          "foo" => { "bar" => Flores::Random.text(0..1000) },
+          "one" => { "two" => { "three" => Flores::Random.text(0..1000) } },
+          "baz" => Flores::Random.text(0..1000),
+        }
       }
-    }
-    let(:length) { Flores::Random.integer(0..1000) }
-    subject { described_class.new("length_bytes" => length) }
-    let(:event) { LogStash::Event.new(data) }
+      let(:length) { Flores::Random.integer(0..1000) }
+      subject { described_class.new("length_bytes" => length) }
+      let(:event) { LogStash::Event.new(data) }
 
-    before { subject.filter(event) }
+      before { subject.filter(event) }
 
-    stress_it "should truncate all strings in the hash" do
-      expect(event.get("[foo][bar]").bytesize).to be <= length
-      if event.get("[foo][bar]").bytesize > length
-        expect(subject).to receive(:filter_matched).once
-      else
-        expect(subject).not_to receive(:filter_matched)
+      stress_it "should truncate all strings in the hash" do
+        expect(event.get("[foo][bar]").bytesize).to be <= length
+        expect(event.get("[one][two][three]").bytesize).to be <= length
+        expect(event.get("baz").bytesize).to be <= length
+      end
+    end
+
+    context "unit test" do
+
+      let(:length) { 450 }
+      subject { described_class.new("length_bytes" => length) }
+      let(:event) { LogStash::Event.new(data) }
+
+      context "fields exceeding length" do
+        let(:data) {
+          {
+            "foo" => { "bar" => "a" * 500 },
+            "one" => { "two" => { "three" => "b" * 600 } },
+            "baz" => "c" * 700,
+          }
+        }
+
+        it "should truncate all strings in the hash" do
+          expect(subject).to receive(:filter_matched).once
+
+          subject.filter(event)
+
+          expect(event.get("[foo][bar]").bytesize).to be <= length
+          expect(event.get("[one][two][three]").bytesize).to be <= length
+          expect(event.get("baz").bytesize).to be <= length
+        end
       end
 
-      expect(event.get("[one][two][three]").bytesize).to be <= length
-      if event.get("[one][two][three]").bytesize > length
-        expect(subject).to receive(:filter_matched).once
-      else
-        expect(subject).not_to receive(:filter_matched)
-      end
+      context "fields not exceeding length" do
+        let(:data) {
+          {
+            "foo" => { "bar" =>"a" * 350 },
+            "one" => { "two" => { "three" => "b" * 300 } },
+            "baz" => "c" * 450,
+          }
+        }
 
-      expect(event.get("baz").bytesize).to be <= length
-      if event.get("baz").bytesize > length
-        expect(subject).to receive(:filter_matched).once
-      else
-        expect(subject).not_to receive(:filter_matched)
+        it "shouldn't truncate strings in the hash" do
+          expect(subject).not_to receive(:filter_matched)
+          foo_bar_prev = event.get("[foo][bar]").bytesize
+          one_two_three_prev = event.get("[one][two][three]").bytesize
+          baz_prev = event.get("baz").bytesize
+
+          subject.filter(event)
+
+          expect(event.get("[foo][bar]").bytesize).to eq foo_bar_prev
+          expect(event.get("[one][two][three]").bytesize).to eq one_two_three_prev
+          expect(event.get("baz").bytesize).to eq baz_prev
+        end
       end
     end
   end
@@ -73,13 +108,13 @@ describe LogStash::Filters::Truncate do
       expect(event.get("message")).to be == text
     end
 
-    stress_it "should only call filter_matched if a field was truncated" do
-      if event.get("example").bytesize > length
-        expect(subject).to receive(:filter_matched).once
-      else
-        expect(subject).not_to receive(:filter_matched)
-      end
-    end
+#     stress_it "should only call filter_matched if a field was truncated" do
+#       if event.get("example").bytesize > length
+#         expect(subject).to receive(:filter_matched).once
+#       else
+#         expect(subject).not_to receive(:filter_matched)
+#       end
+#     end
   end
 
   context "with non-string fields" do
@@ -102,17 +137,49 @@ describe LogStash::Filters::Truncate do
     subject { described_class.new("length_bytes" => length, "fields" => [ "example" ]) }
     let(:event) { LogStash::Event.new("example" => list) }
 
-    before { subject.filter(event) }
+    context "stress test" do
+      before { subject.filter(event) }
 
-    stress_it "should truncate all elements in a list" do
-      count.times do |i| 
-        expect(event.get("[example][#{i}]").bytesize).to be <= length
+      stress_it "should truncate all elements in a list" do
+        count.times do |i|
+          expect(event.get("[example][#{i}]").bytesize).to be <= length
 
-        if event.get("[example][#{i}]").bytesize > length
-          expect(subject).to receive(:filter_matched).once
-        else
-          expect(subject).not_to receive(:filter_matched)
+          if event.get("[example][#{i}]").bytesize > length
+            expect(subject).to receive(:filter_matched).once
+          else
+            expect(subject).not_to receive(:filter_matched)
+          end
         end
+      end
+    end
+
+    context "containing elements greater than size" do
+      let(:count) { 10 }
+      let(:list) { count.times.map { Flores::Random.text(100) } }
+      let(:length) { 50 }
+
+      it "should truncate all elements" do
+        expect(subject).to receive(:filter_matched).once
+
+        subject.filter(event)
+
+        count.times do |i|
+          expect(event.get("[example][#{i}]").bytesize).to be <= length
+        end
+      end
+    end
+
+    context "containing elements with mixed sizes" do
+      let(:count) { 10 }
+      let(:list) { (count - 1).times.map { Flores::Random.text(20) } + [Flores::Random.text(100)]}
+      let(:length) { 50 }
+
+      it "should truncate elements that exceed the length" do
+        expect(subject).to receive(:filter_matched).once
+
+        subject.filter(event)
+
+        expect(event.get("[example][#{count - 1}]").bytesize).to be <= length
       end
     end
   end

--- a/spec/filters/truncate_spec.rb
+++ b/spec/filters/truncate_spec.rb
@@ -141,7 +141,7 @@ describe LogStash::Filters::Truncate do
 
     context "containing elements greater than size" do
       let(:count) { 10 }
-      let(:list) { count.times.map { "a" * 100) } }
+      let(:list) { count.times.map { "a" * 100 } }
       let(:length) { 50 }
 
       it "should truncate all elements" do


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Bugfix to add tags and fields only when the truncation happens on any Event's fields.

## What does this PR do?

This PR resolves the issue described in https://github.com/logstash-plugins/logstash-filter-truncate/issues/4 where options such as `add_tag` and `add_field` are always executed by this plugin regardless of whether truncation has actually taken place.

This adds some logic to check if at least one field from the event has been modified by the truncation method and if so then it calls `filter_matched`. I didn't want to change too much to be able to determine if a truncation has taken place so I've done it by adding an equality check after the `truncate()` function has been called.

I tried to extend the existing tests to include coverage around this new logic but I'm very rusty with rspec so any better approaches are welcome.

## Why is it important/What is the impact to the user?

An example use case this enables is if you want to add a tag to see which events are being truncated, that isn't possible currently because the tag is always added.

The documentation also [implies](https://www.elastic.co/guide/en/logstash/current/plugins-filters-truncate.html#plugins-filters-truncate-add_tag) that these would only be run if the filter was "successful". To me that means something was truncated.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist



## How to test this PR locally

I tested it by running the tests and installing this into my local logstash instance and manually verifying it behaves as expected.

## Related issues

- Fixes #4 
- Relates #2
- Relates #3 

## Use cases

This enables running `add_tag`, `remove_tag`, `add_field` and `remove_field` conditionally based on if truncation has taken place on at least one field.

## Screenshots

N/A

## Logs

N/A
